### PR TITLE
fix: solve the problem of wrong injection location in Vite@3

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ export function importMaps(options: ImportMap[] | (() => ImportMap[])): Plugin {
       }
     },
     transformIndexHtml: {
-      enforce: 'pre',
+      enforce: 'post',
       transform(html) {
         return {
           html,


### PR DESCRIPTION
### **Description**
This PR fixes #2, adjusts the plugin execution order, and ensures that the result is correctly injected at the top of the head tag under Vite@3.

这个 PR 修复了 #2，调整了插件的执行顺序，确保在Vite 3下能够正确将结果注入到head标签顶部。

fixes #2

### **What is the purpose of this pull request?**
 
- [x] Bug fix
- [ ]  New Feature
- [ ]  Documentation update
- [ ] Other